### PR TITLE
sustitucion flex por grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,9 @@ footer {
    
 }
 
+.blog__entradas article {
+   text-align: center;
+}
 
 /*
 .tabla {
@@ -554,7 +557,7 @@ nav {
    #inputHeader {
    grid-area: search;
    }
-   #contenidoBlog__grilla {
+   #contenidoBlog__layout {
    grid-area: entradasblog;
    }
    footer {
@@ -571,6 +574,7 @@ nav {
 }
    
 
+
 .contenidoBlog__flex {
    display: flex;
    flex-direction: column;
@@ -578,19 +582,19 @@ nav {
    align-items: center;
 }
 
-#contenidoBlog__grilla {
-   display: grid;
+#contenidoBlog__layout {
+   display: flex;
    column-gap: 10px;
    row-gap: 10px; 
    padding: 5%;
-   justify-content: center;
+
 }
 
-#contenidoBlog__grilla img {
+#contenidoBlog__layout img {
    max-width: 95%;
    }
    
-#contenidoBlog__grilla p {
+#contenidoBlog__layout p {
       font-family: 'Roboto', sans-serif;
       font-size: 0.8em;
       text-align: center;
@@ -599,7 +603,7 @@ nav {
       color: #3B4611;
    }
    
-#contenidoBlog__grilla h4 {
+#contenidoBlog__layout h4 {
       font-size: 1em;
       padding: 5%;
       color: #3B4611;
@@ -607,7 +611,7 @@ nav {
       text-align: center;
    }
    
-   #contenidoBlog__grilla a {
+   #contenidoBlog__layout a {
       font-size: 0.9em;
       font-family: 'Roboto', sans-serif;
       color: #A8B440;
@@ -615,9 +619,13 @@ nav {
    }
    
    @media screen and (min-width: 320px) {
-      #contenidoBlog__grilla {
-         grid-template-columns: 100%;
+      #contenidoBlog__layout {
+         flex-direction: column;
+         flex-wrap: nowrap;
+         justify-content: center;
       }
+      
+      
      .headerBlog__desktop {
          display: none;
      }
@@ -631,10 +639,17 @@ nav {
    }
 
    @media screen and (min-width: 768px) {
-      #contenidoBlog__grilla {
-         grid-template-columns: 32% 32% 32%;
-         grid-template-rows: repeat(2, auto);
+      #contenidoBlog__layout {
+         flex-direction: row;
+         flex-wrap: wrap;
+         justify-content: space-evenly;
       }
+      
+      
+      .contenidoBlog__flex {
+         width: 30%;
+      }
+      
       .headerBlog__mobile {
          display: none;
          }

--- a/pages/blog.html
+++ b/pages/blog.html
@@ -45,7 +45,9 @@
     
     </header>
     
-    <div id="contenidoBlog__grilla">
+    <div id="contenidoBlog__layout">
+    
+        
         <div class="contenidoBlog__flex">
             <img src="../assets/img/pan.jpg" alt="tres panes caseros" class="contenidoBlog__imagen" id="pan">
             <h4>#1 Mito: comer pan engorda</h4>
@@ -75,9 +77,11 @@
            <a src="">Leer más</a>
         </div>
     
+        <div class="contenidoBlog__flex">
+        </div>
         
-        
-        
+        <div class="contenidoBlog__flex">
+        </div>
         
     </div>
     


### PR DESCRIPTION
En index (sección blog) se alineó la imagen y el título (a).
En blog se cambió el layout: ahora es grilla, cuando antes era grid. Se ve similar, hay que seguir probando cómo lograr la referencia: 
https://www.squarespace.com/websites/create-a-blog/?channel=pnb&subchannel=go&campaign=pnb-go-row_sa-en-verticals_general-e&subcampaign=(blog_blog_e)&&cid=14267506724&aid=124681814286&tid=kwd-21745101&mt=e&eid=&loc_p_ms=1012872&loc_i_ms=&nw=g&d=c&adid=539023684241&channel2=pnb&subchannel2=go&gclid=Cj0KCQjw8amWBhCYARIsADqZJoUZuHOSegcuFvU5qOclI2iK4g9n1Lz7CGRjjX9IoB2_YqY5abZ_lYIaAiaGEALw_wcB&gclsrc=aw.ds